### PR TITLE
Remove rc references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GLOOE_DIR := _glooe
 _ := $(shell mkdir -p $(GLOOE_DIR))
 
 # Set this variable to the version of GlooE you want to target
-GLOOE_VERSION ?= 1.0.0-rc10
+GLOOE_VERSION ?= 1.2.1
 
 .PHONY: get-glooe-info
 get-glooe-info: $(GLOOE_DIR)/dependencies $(GLOOE_DIR)/verify-plugins-linux-amd64 $(GLOOE_DIR)/build_env

--- a/changelog/v0.2.0/update-glooe-refs.yaml
+++ b/changelog/v0.2.0/update-glooe-refs.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NON_USER_FACING
+  description: >
+    Update the default Gloo Enterprise version for which to fetch dependencies to `1.2.0`.

--- a/changelog/v0.2.0/update-glooe-refs.yaml
+++ b/changelog/v0.2.0/update-glooe-refs.yaml
@@ -1,4 +1,4 @@
 changelog:
 - type: NON_USER_FACING
   description: >
-    Update the default Gloo Enterprise version for which to fetch dependencies to `1.2.0`.
+    Update the default Gloo Enterprise version for which to fetch dependencies to `1.2.1`.

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.5 // indirect
 	github.com/armon/go-metrics v0.3.0 // indirect
 	github.com/avast/retry-go v2.4.3+incompatible // indirect
+	github.com/bxcodec/faker v2.0.1+incompatible // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/chai2010/gettext-go v0.0.0-20170215093142-bf70f2a70fb1 // indirect
 	github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017 // indirect
@@ -46,7 +47,7 @@ require (
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/prometheus/tsdb v0.10.0 // indirect
 	github.com/solo-io/ext-auth-plugins v0.1.1
-	github.com/solo-io/go-utils v0.11.1
+	github.com/solo-io/go-utils v0.11.5
 	github.com/solo-io/solo-kit v0.11.13 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/viper v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -479,6 +479,8 @@ github.com/solo-io/go-utils v0.11.1 h1:Y/46OhkxfJZf6oSR95CjQJLyoN2odSsK6FAP5eZ2V
 github.com/solo-io/go-utils v0.11.1/go.mod h1:hRe968ntd1xSro9RYSln5qAjHXGJ+aQ1h8piZvdzc3A=
 github.com/solo-io/go-utils v0.11.2 h1:OvhJLktMdlJj/oqxwvLg3iv3p6QI+zTep0q2UVwGJ2o=
 github.com/solo-io/go-utils v0.11.2/go.mod h1:D5lbi4EyIMq+T5gzjJacu0Ou4Z1brL7g2YYYYgYBJso=
+github.com/solo-io/go-utils v0.11.5 h1:7WPbpDvwB6MUCYtHSr/GznIwTPkTU6Rg/gFDpid8nTM=
+github.com/solo-io/go-utils v0.11.5/go.mod h1:D5lbi4EyIMq+T5gzjJacu0Ou4Z1brL7g2YYYYgYBJso=
 github.com/solo-io/solo-kit v0.6.3/go.mod h1:oBaQ6tOwuO97u7w+s3TeI08YLHcbiWemInx0XkDfKFw=
 github.com/solo-io/solo-kit v0.11.13/go.mod h1:oBaQ6tOwuO97u7w+s3TeI08YLHcbiWemInx0XkDfKFw=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
Update the default Gloo Enterprise version for which to fetch dependencies to `1.2.1`.